### PR TITLE
FIX: performance to import records in batch with fields m2o

### DIFF
--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -346,7 +346,6 @@ class IrFieldsConverter(models.AbstractModel):
             field_type = _(u"name")
             if value == '':
                 return False, field_type, warnings
-            flush()
             ids = RelatedModel.name_search(name=value, operator='=')
             if ids:
                 if len(ids) > 1:


### PR DESCRIPTION
Complementary to commit d5b687a48ffbd9fc952b4fef7089b8c83399e2dd

Avoid import records one by one, on method db_id_for when field is many2one and csv file contain Record Name(field_name on header)(not field_name/id or field_name/.id) import is done for each record on each iteration with method flush pass on context

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
